### PR TITLE
Push message fix and cleanup

### DIFF
--- a/BBCloud_POSTReceiveHook.js
+++ b/BBCloud_POSTReceiveHook.js
@@ -35,11 +35,10 @@ const processors = {
             message: request.content.push.changes[0].new.target.message
         };
         const links = {
-            self: request.content.push.changes[0].new.target.links.self.href
+            self: request.content.push.changes[0].new.links.html.href
         };
         let text = '';
         text += author.displayname + ' (@' + author.username + ') pushed changes:\n';
-        text += '=> ' + repository.name + '/' + repository.branch + '\n';
         text += repository.message + '\n';
         const attachment = {
             author_icon: 'http://plainicon.com/dboard/userprod/2800_a1826/prod_thumb/plainicon.com-50220-512px-3ba.png',


### PR DESCRIPTION
* Fix commit link: link was pointing to the api url. It has been changed to the webinterface url, so it can be shown directly in the browser
* Removed duplicated branch name: Branch name was written twice in the message - with the link to the repository and without. Now it is only written once with link.