### PR TITLE
Fix broken author link

### DIFF
--- a/BBCloud_POSTReceiveHook.js
+++ b/BBCloud_POSTReceiveHook.js
@@ -30,7 +30,7 @@ const showNotifications = {
 function get_basic_info(request) {
   const author = {
       displayname: request.content.actor.display_name,
-      link: request.content.actor.links.html,
+      link: request.content.actor.links.html.href,
       avatar: request.content.actor.links.avatar.href
   };
   const repository = {


### PR DESCRIPTION
So a few days ago our BitBucket integration via BitRocket broke. I don't know if BitBucket decided to update their request objects to be more consistent or something but this PR fixed the issues we had.