### PR TITLE
Correct PR repo links

### DIFF
--- a/bitbucket_5_6_native-webhook.js
+++ b/bitbucket_5_6_native-webhook.js
@@ -176,6 +176,7 @@ const processors = {
         let text = '';
         text += '@' + author.username + ' opened a new pull request:\n';
         text += '`' + pullRequest.sourcerepo + '/' + pullRequest.sourcebranch + '` => `' + pullRequest.destrepo + '/' + pullRequest.destinationbranch + '`\n\n';
+        text += 'Title: (' + pullRequest.id + ') ' + pullRequest.title + '\n';
         text += 'Description:\n';
         text += pullRequest.description + '\n';
         const attachment = {
@@ -210,7 +211,7 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' approved a pull request from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' approved pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'APPROVED: ' + '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -244,7 +245,7 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' unapproved a pull request from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' unapproved pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'UNAPPROVED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -277,7 +278,7 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' says, a pull request from @' + pullrequest.author + ' needs work:\n';
+        text += '@' + author.username + ' says, pull request ' + pullRequest.id + ' from @' + pullrequest.author + ' needs work:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'NEEDS WORK: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -310,7 +311,7 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' merged a pull request from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' merged pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'MERGED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -343,7 +344,7 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' declined a pull request from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' declined pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'DECLINED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -376,7 +377,7 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' deleted a pull request from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' deleted pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'DELETED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,

--- a/bitbucket_5_6_native-webhook.js
+++ b/bitbucket_5_6_native-webhook.js
@@ -203,13 +203,14 @@ const processors = {
             destinationbranch: content.pullRequest.toRef.id,
             projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
+            author: content.pullRequest.author.user.name,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' approved a pull request:\n';
+        text += '@' + author.username + ' approved a pull request from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'APPROVED: ' + '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -236,13 +237,14 @@ const processors = {
             destinationbranch: content.pullRequest.toRef.id,
             projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
+            author: content.pullRequest.author.user.name,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' unapproved a pull request:\n';
+        text += '@' + author.username + ' unapproved a pull request from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'UNAPPROVED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -268,13 +270,14 @@ const processors = {
             destinationbranch: content.pullRequest.toRef.id,
             projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
+            author: content.pullRequest.author.user.name,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' says, a pull request needs work:\n';
+        text += '@' + author.username + ' says, a pull request from @' + pullrequest.author + ' needs work:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'NEEDS WORK: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -300,13 +303,14 @@ const processors = {
             destinationbranch: content.pullRequest.toRef.id,
             projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
+            author: content.pullRequest.author.user.name,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' merged a pull request:\n';
+        text += '@' + author.username + ' merged a pull request from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'MERGED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -332,13 +336,14 @@ const processors = {
             destinationbranch: content.pullRequest.toRef.id,
             projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
+            author: content.pullRequest.author.user.name,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' declined a pull request:\n';
+        text += '@' + author.username + ' declined a pull request from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'DECLINED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
@@ -364,13 +369,14 @@ const processors = {
             destinationbranch: content.pullRequest.toRef.id,
             projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
+            author: content.pullRequest.author.user.name,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' deleted a pull request:\n';
+        text += '@' + author.username + ' deleted a pull request from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
             author_name: 'DELETED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,

--- a/bitbucket_5_6_native-webhook.js
+++ b/bitbucket_5_6_native-webhook.js
@@ -163,7 +163,7 @@ const processors = {
         const pullRequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -201,7 +201,7 @@ const processors = {
         const pullrequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -212,7 +212,7 @@ const processors = {
         text += '@' + author.username + ' approved a pull request:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'APPROVED: ' + pullrequest.title,
+            author_name: 'APPROVED: ' + '#' + pullRequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -234,7 +234,7 @@ const processors = {
         const pullrequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -245,7 +245,7 @@ const processors = {
         text += '@' + author.username + ' unapproved a pull request:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'UNAPPROVED: ' + pullrequest.title,
+            author_name: 'UNAPPROVED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -266,7 +266,7 @@ const processors = {
         const pullrequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -277,7 +277,7 @@ const processors = {
         text += '@' + author.username + ' says, a pull request needs work:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'NEEDS WORK: ' + pullrequest.title,
+            author_name: 'NEEDS WORK: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -298,7 +298,7 @@ const processors = {
         const pullrequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -309,7 +309,7 @@ const processors = {
         text += '@' + author.username + ' merged a pull request:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'MERGED: ' + pullrequest.title,
+            author_name: 'MERGED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -330,7 +330,7 @@ const processors = {
         const pullrequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -341,7 +341,7 @@ const processors = {
         text += '@' + author.username + ' declined a pull request:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'DECLINED: ' + pullrequest.title,
+            author_name: 'DECLINED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -362,7 +362,7 @@ const processors = {
         const pullrequest = {
             sourcebranch: content.pullRequest.fromRef.id,
             destinationbranch: content.pullRequest.toRef.id,
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
             sourcerepo: content.pullRequest.fromRef.repository.name,
             destrepo: content.pullRequest.toRef.repository.name,
@@ -373,7 +373,7 @@ const processors = {
         text += '@' + author.username + ' deleted a pull request:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'DELETED: ' + pullrequest.title,
+            author_name: 'DELETED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -388,9 +388,9 @@ const processors = {
 
     pr_comment_added(content) {
         const pullRequest = {
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
-            repo: content.pullRequest.fromRef.repository.name
+            repo: content.pullRequest.toRef.repository.name
         };
         const author = {
             username: content.actor.name
@@ -418,9 +418,9 @@ const processors = {
 
     pr_comment_deleted(content) {
         const pullRequest = {
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
-            repo: content.pullRequest.fromRef.repository.name
+            repo: content.pullRequest.toRef.repository.name
         };
         const author = {
             username: content.actor.name
@@ -448,9 +448,9 @@ const processors = {
 
     pr_comment_edited(content) {
         const pullRequest = {
-            projectKey: content.pullRequest.fromRef.repository.project.key,
+            projectKey: content.pullRequest.toRef.repository.project.key,
             id: content.pullRequest.id,
-            repo: content.pullRequest.fromRef.repository.name
+            repo: content.pullRequest.toRef.repository.name
         };
         const author = {
             username: content.actor.name

--- a/bitbucket_5_6_native-webhook.js
+++ b/bitbucket_5_6_native-webhook.js
@@ -211,10 +211,10 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' approved pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' approved pull request ' + pullrequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'APPROVED: ' + '#' + pullRequest.id + ' - ' + pullrequest.title,
+            author_name: 'APPROVED: ' + '#' + pullrequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -245,10 +245,10 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' unapproved pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' unapproved pull request ' + pullrequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'UNAPPROVED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
+            author_name: 'UNAPPROVED: ' +  '#' + pullrequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -278,10 +278,10 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' says, pull request ' + pullRequest.id + ' from @' + pullrequest.author + ' needs work:\n';
+        text += '@' + author.username + ' says, pull request ' + pullrequest.id + ' from @' + pullrequest.author + ' needs work:\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'NEEDS WORK: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
+            author_name: 'NEEDS WORK: ' +  '#' + pullrequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -311,10 +311,10 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' merged pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' merged pull request ' + pullrequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'MERGED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
+            author_name: 'MERGED: ' +  '#' + pullrequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -343,11 +343,10 @@ const processors = {
             title: content.pullRequest.title,
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
-        let text = '';
-        text += '@' + author.username + ' declined pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' declined pull request ' + pullrequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'DECLINED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
+            author_name: 'DECLINED: ' +  '#' + pullrequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {
@@ -377,10 +376,10 @@ const processors = {
             description: content.pullRequest.description ? content.pullRequest.description : ''
         };
         let text = '';
-        text += '@' + author.username + ' deleted pull request ' + pullRequest.id + ' from @' + pullrequest.author + ':\n';
+        text += '@' + author.username + ' deleted pull request ' + pullrequest.id + ' from @' + pullrequest.author + ':\n';
         text += '`' + pullrequest.sourcerepo + '/' + pullrequest.sourcebranch + '` => `' + pullrequest.destrepo + '/' + pullrequest.destinationbranch + '`\n\n';
         const attachment = {
-            author_name: 'DELETED: ' +  '#' + pullRequest.id + ' - ' + pullrequest.title,
+            author_name: 'DELETED: ' +  '#' + pullrequest.id + ' - ' + pullrequest.title,
             author_link: config.bitbucketUrl + '/projects/' + pullrequest.projectKey + '/repos/' + pullrequest.sourcerepo + '/pull-requests/' + pullrequest.id + '/overview'
         };
         return {


### PR DESCRIPTION
404 errors result from using the fromRef, as PRs are related to the destination repo, so toRef needs to be used for the project. It was already used to get the repo name.

Second commit makes the message text mention the author of the PR, who is probably the most interested in event, more so than the person actually taking the action.